### PR TITLE
Type casting integers to uint8_t

### DIFF
--- a/DFRobot_PN532.cpp
+++ b/DFRobot_PN532.cpp
@@ -7,7 +7,6 @@
 #endif
 #include <Wire.h>
 #define PN532_PACKBUFFSIZ 64
-
 /*!
     The NTAG's EEPROM memory is organized in pages with 4 bytes per page. NTAG213 variant has
     45 pages, NTAG215 variant has 135 pages and NTAG216 variant has 231 pages in total.
@@ -365,7 +364,6 @@ bool DFRobot_PN532::writeData(int block, uint8_t data[])
     this->readAck(16);
     return true;
 }
-
 /*!
    It takes three steps to write a piece of data to a card
    1.Read out all the data for one block(every block have 16 data.).

--- a/DFRobot_PN532.cpp
+++ b/DFRobot_PN532.cpp
@@ -8,9 +8,6 @@
 #include <Wire.h>
 #define PN532_PACKBUFFSIZ 64
 
-#define SDA_PIN 21
-#define SCL_PIN 22
-
 /*!
     The NTAG's EEPROM memory is organized in pages with 4 bytes per page. NTAG213 variant has
     45 pages, NTAG215 variant has 135 pages and NTAG216 variant has 231 pages in total.
@@ -369,16 +366,6 @@ bool DFRobot_PN532::writeData(int block, uint8_t data[])
     return true;
 }
 
-const int min(const uint8_t a, const int b)
-{
-    return (b < a) ? b : a;
-}
-
-const int max(const int a, const int b)
-{
-    return (b > a) ? b : a;
-}
-
 /*!
    It takes three steps to write a piece of data to a card
    1.Read out all the data for one block(every block have 16 data.).
@@ -654,7 +641,7 @@ bool DFRobot_PN532_IIC::begin(void) {   //nfc Module initialization
     cmdWrite[1] = 0x01; // normal mode;
     cmdWrite[2] = 0x14; // timeout 50ms * 20 = 1 second
     cmdWrite[3] = 0x01; // use IRQ pin!
-    Wire.begin(SDA_PIN, SCL_PIN);
+    Wire.begin();
     nfcEnable = true;
     writeCommand(cmdWrite,4);
     delay(10);

--- a/DFRobot_PN532.cpp
+++ b/DFRobot_PN532.cpp
@@ -375,7 +375,7 @@ void DFRobot_PN532::writeData(int block, uint8_t index, uint8_t data)
 {
     if(!this->nfcEnable)
         return;
-    index = max(min(index,16),1);
+    index = max(min(index, (uint8_t)16), (uint8_t)1);
     this->readData(block);
     this->blockData[index - 1] = data;
     this->writeData(block, this->blockData);

--- a/DFRobot_PN532.cpp
+++ b/DFRobot_PN532.cpp
@@ -7,6 +7,10 @@
 #endif
 #include <Wire.h>
 #define PN532_PACKBUFFSIZ 64
+
+#define SDA_PIN 21
+#define SCL_PIN 22
+
 /*!
     The NTAG's EEPROM memory is organized in pages with 4 bytes per page. NTAG213 variant has
     45 pages, NTAG215 variant has 135 pages and NTAG216 variant has 231 pages in total.
@@ -364,6 +368,17 @@ bool DFRobot_PN532::writeData(int block, uint8_t data[])
     this->readAck(16);
     return true;
 }
+
+const int min(const uint8_t a, const int b)
+{
+    return (b < a) ? b : a;
+}
+
+const int max(const int a, const int b)
+{
+    return (b > a) ? b : a;
+}
+
 /*!
    It takes three steps to write a piece of data to a card
    1.Read out all the data for one block(every block have 16 data.).
@@ -639,7 +654,7 @@ bool DFRobot_PN532_IIC::begin(void) {   //nfc Module initialization
     cmdWrite[1] = 0x01; // normal mode;
     cmdWrite[2] = 0x14; // timeout 50ms * 20 = 1 second
     cmdWrite[3] = 0x01; // use IRQ pin!
-    Wire.begin();
+    Wire.begin(SDA_PIN, SCL_PIN);
     nfcEnable = true;
     writeCommand(cmdWrite,4);
     delay(10);


### PR DESCRIPTION
The library can not be compiled when the arguments of the min and max methods are not of the same type. Casting the integers to uint8_t fixes the problem.